### PR TITLE
feat : spring security deprecated 된 부분 수정, 폴더 구조 변경, enum Roles 추가

### DIFF
--- a/src/main/java/com/survey/domain/user/controller/UserApiController.java
+++ b/src/main/java/com/survey/domain/user/controller/UserApiController.java
@@ -1,8 +1,7 @@
-package com.survey.user.controller;
+package com.survey.domain.user.controller;
 
-import com.survey.user.dto.UserRequestDto;
-import com.survey.user.service.UserDetailService;
-import com.survey.user.service.UserService;
+import com.survey.domain.user.dto.UserRequestDto;
+import com.survey.domain.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/survey/domain/user/controller/UserViewController.java
+++ b/src/main/java/com/survey/domain/user/controller/UserViewController.java
@@ -1,4 +1,4 @@
-package com.survey.user.controller;
+package com.survey.domain.user.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/survey/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/survey/domain/user/dto/UserRequestDto.java
@@ -1,4 +1,4 @@
-package com.survey.user.dto;
+package com.survey.domain.user.dto;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/survey/domain/user/entity/User.java
+++ b/src/main/java/com/survey/domain/user/entity/User.java
@@ -1,6 +1,7 @@
-package com.survey.user.entity;
+package com.survey.domain.user.entity;
 
 
+import com.survey.domain.user_role.Roles;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -30,16 +31,20 @@ public class User implements UserDetails {
     @Column(name = "password", nullable = false)
     private String password;
 
+    @Enumerated(EnumType.STRING)
+    private Roles role;
+
     @Builder
-    public User(String email, String password) {
+    public User(String email, String password, Roles role) {
         this.email = email;
         this.password = password;
+        this.role = role;
     }
 
     // 권한 반환
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("user"));
+        return List.of(new SimpleGrantedAuthority(Roles.USER.getRole()));
     }
 
     // 사용자 아이디(email) 반환

--- a/src/main/java/com/survey/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/survey/domain/user/repository/UserRepository.java
@@ -1,6 +1,6 @@
-package com.survey.user.repository;
+package com.survey.domain.user.repository;
 
-import com.survey.user.entity.User;
+import com.survey.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/survey/domain/user/service/UserDetailService.java
+++ b/src/main/java/com/survey/domain/user/service/UserDetailService.java
@@ -1,6 +1,6 @@
-package com.survey.user.service;
+package com.survey.domain.user.service;
 
-import com.survey.user.repository.UserRepository;
+import com.survey.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/com/survey/domain/user/service/UserService.java
+++ b/src/main/java/com/survey/domain/user/service/UserService.java
@@ -1,8 +1,8 @@
-package com.survey.user.service;
+package com.survey.domain.user.service;
 
-import com.survey.user.dto.UserRequestDto;
-import com.survey.user.entity.User;
-import com.survey.user.repository.UserRepository;
+import com.survey.domain.user.repository.UserRepository;
+import com.survey.domain.user.dto.UserRequestDto;
+import com.survey.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/survey/domain/user_role/Roles.java
+++ b/src/main/java/com/survey/domain/user_role/Roles.java
@@ -1,0 +1,16 @@
+package com.survey.domain.user_role;
+
+import lombok.Getter;
+
+@Getter
+public enum Roles {
+    USER("USER"),
+    MANAGER("MANAGER"),
+    ADMIN("ADMIN");
+
+    private String role;
+
+    Roles(String role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/com/survey/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/survey/global/config/WebSecurityConfig.java
@@ -1,4 +1,4 @@
-package com.survey.config;
+package com.survey.global.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +8,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -17,6 +18,7 @@ import static org.springframework.boot.autoconfigure.security.servlet.PathReques
 @RequiredArgsConstructor
 @Configuration
 public class WebSecurityConfig {
+    //deprecated 된 부분 수정
 
     private final UserDetailsService userService;
 
@@ -27,36 +29,28 @@ public class WebSecurityConfig {
                 .requestMatchers("/static/**");
     }
 
-    @Bean
+    @Bean //deprecated 된 부분 수정
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        return http
-                .authorizeRequests()
-                .requestMatchers("/login", "/signup", "/user")
-                .permitAll()
-                .anyRequest()
-                .authenticated()
-                .and()
-                .formLogin()
-                .loginPage("/login")
-                .defaultSuccessUrl("/articles")
-                .and()
-                .logout()
-                .logoutSuccessUrl("/login")
-                .invalidateHttpSession(true)
-                .and()
-                .csrf().disable()
-                .build();
+        http.authorizeHttpRequests(auth -> auth.requestMatchers("/login", "/signup", "/user").permitAll()
+                .anyRequest().authenticated());
+
+        http.formLogin(formLogin -> formLogin.loginPage("/login")
+                                .defaultSuccessUrl("/articles"))
+                        .logout(logout -> logout.logoutSuccessUrl("/login")
+                                .invalidateHttpSession(true))
+                        .csrf(AbstractHttpConfigurer::disable);
+
+        return http.build();
     }
 
-    @Bean
-    public AuthenticationManager authenticationManager(HttpSecurity http, BCryptPasswordEncoder bCryptPasswordEncoder,
-                                                       UserDetailsService userDetailsService) throws Exception {
-        return http.getSharedObject(AuthenticationManagerBuilder.class)
-                .userDetailsService(userService)
-                .passwordEncoder(bCryptPasswordEncoder)
-                .and()
-                .build();
+    @Bean //deprecated 수정
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder authenticationManagerBuilder = http.getSharedObject(AuthenticationManagerBuilder.class);
+        authenticationManagerBuilder.userDetailsService(userService).passwordEncoder(bCryptPasswordEncoder());
+
+        return authenticationManagerBuilder.build();
     }
+
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {


### PR DESCRIPTION
1. spring security6 버전을 사용하면서 deprecated 된 메서드 체이닝 형식 -> 함수형 형식, .and() 제거
2. 폴더 구조 변경 __domain
|    |__user
|
|__global
     |__config

3. Roles enum 타입 추가